### PR TITLE
Added env var to set target.lst

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,17 @@ cd ..
 
 Upon a successful build the binary, rocminfo, and the python script, rocm_agent_enumerator, will be in the build folder.
 
+## Execution
+
+"rocminfo" gives information about the HSA system attributes and agents.
+
+"rocm_agent_enumerator" prints the list of available AMD GCN ISA. There exist four different ways how it is generated:
+
+1. ROCM_TARGET_LST : a user defined environment variable, set to the path and filename where to find the "target.lst" file. This can be used in an install environment with sandbox, where execution of "rocminfo" is not possible.
+
+2. target.lst : user-supplied text file, in the same folder as "rocm_agent_enumerator". This is used in a container setting where ROCm stack may usually not available.
+
+3. rocminfo : a tool shipped with this script to enumerate GPU agents available on a working ROCm stack.
+
+4. lspci : enumerate PCI bus and locate supported devices from a hard-coded lookup table.
+

--- a/rocm_agent_enumerator
+++ b/rocm_agent_enumerator
@@ -68,7 +68,7 @@ def readFromTargetLstFile():
       target = getGCNISA(line, match_from_beginning = True)
       if target is not None:
         target_list.append(target)
-    
+
   return target_list
 
 def readFromROCMINFO():
@@ -123,11 +123,15 @@ def main():
   The program collects the list in 3 different ways, in the order of
   precendence:
 
-  1. target.lst : user-supplied text file. This is used in a container setting
+  1. ROCM_TARGET_LST : a user defined environment variable, set to the path and
+                       filename where to find the "target.lst" file. This can be
+                       used in an install environment with sandbox, where
+                       execution of "rocminfo" is not possible.
+  2. target.lst : user-supplied text file. This is used in a container setting
                   where ROCm stack may usually not available.
-  2. rocminfo : a tool shipped with this script to enumerate GPU agents
+  3. rocminfo : a tool shipped with this script to enumerate GPU agents
                 available on a working ROCm stack.
-  3. lspci : enumerate PCI bus and locate supported devices from a hard-coded
+  4. lspci : enumerate PCI bus and locate supported devices from a hard-coded
              lookup table.
   """
   target_list = readFromTargetLstFile()
@@ -141,7 +145,7 @@ def main():
   # workaround to cope with existing rocm_agent_enumerator behavior where gfx000
   # would always be returned
   print("gfx000")
-  
+
   for gfx in target_list:
     print(gfx)
 

--- a/rocm_agent_enumerator
+++ b/rocm_agent_enumerator
@@ -55,9 +55,11 @@ def getGCNISA(line, match_from_beginning = False):
 def readFromTargetLstFile():
   target_list = []
 
-  # locate target.lst which should be placed at the same directory with this
-  # script
-  target_lst_path = os.path.join(CWD, "target.lst")
+  # locate target.lst using environment variable or
+  # it should be placed at the same directory with this script
+  target_lst_path = os.environ.get("ROCM_TARGET_LST");
+  if target_lst_path == None:
+    target_lst_path = os.path.join(CWD, "target.lst")
   if os.path.isfile(target_lst_path):
     target_lst_file = open(target_lst_path, 'r')
     for line in target_lst_file:


### PR DESCRIPTION
Extends the "rocm_agent_enumerator" to read the "target.lst" from a location set by env var "ROCM_TARGET_LST". If not set, it does not change anything, the behaviour is like before.

In the install scripts for Gentoo Linux execution of "rocm_agent_enumerator" respectively "rocminfo" is not allowed, due to a sandbox. Using this env var gives the possibility to adjust the "target.lst" file and store it locally, while installing new ROCm software. 
 