### PR TITLE
Fix rocminfo when run within docker environments.

### DIFF
--- a/rocminfo.cc
+++ b/rocminfo.cc
@@ -1050,7 +1050,7 @@ int CheckInitialState(void) {
 
         std::string line;
         bool docker_env = false;
-	while ( std::getline(buffer, line) ) {
+        while ( std::getline(buffer, line) ) {
             if ( line.find( "docker" )) {
                 docker_env = true;
                 printf("Docker environment detected - missing ROCk module expected.\n");

--- a/rocminfo.cc
+++ b/rocminfo.cc
@@ -1058,6 +1058,9 @@ int CheckInitialState(void) {
 	    }
         }
         if ( !docker_env ) return -1;
+    } else {
+        // this is certainly weird - error
+        return -1;
     }
   } else {
     printf("%sROCk module is loaded%s\n", COL_WHT, COL_RESET);


### PR DESCRIPTION
Currently, rocminfo will fail when executed inside a docker container
due to a missing ROCk module. This has impacts on rocprofiler use.
However, a missing ROCk module is expected within a docker environment.

Fix this by searching for the "docker" string within the self-cgroups.
If it is found, we do not error on a missing ROCk module.