### PR TITLE
Use idomatic approach to extending CMAKE_MODULE_PATH.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,9 +50,7 @@ endif()
 # Default to ON
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 ## Set default module path if not already set
-if(NOT DEFINED CMAKE_MODULE_PATH)
-    set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-endif()
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
 ## Include common cmake modules
 include(utils)
 


### PR DESCRIPTION
There are many reasons why there may already be a CMAKE_MODULE_PATH defined. The idiomatic way to extend it in a project is via `list(APPEND`.