### PR TITLE
External CI: change trigger from amd-master to amd-mainline

### DIFF
--- a/.azuredevops/rocm-ci.yml
+++ b/.azuredevops/rocm-ci.yml
@@ -21,7 +21,7 @@ trigger:
   branches:
     include:
     - amd-staging
-    - amd-master
+    - amd-mainline
   paths:
     exclude:
     - .github
@@ -33,7 +33,7 @@ pr:
   branches:
     include:
     - amd-staging
-    - amd-master
+    - amd-mainline
   paths:
     exclude:
     - .github


### PR DESCRIPTION
Changes a branch trigger from amd-master to amd-mainline.