### PR TITLE
rocminfo: Add gfx11/gfx12 device IDs to rocm_agent_enumerator

### DIFF
--- a/rocm_agent_enumerator
+++ b/rocm_agent_enumerator
@@ -77,12 +77,17 @@ ISA_TO_ID = {
   # Yellow_Carp
   "gfx1035" : [0x164d, 0x1681],
 
-  # Navi31
-  "gfx1100": [0x7448, 0x7449, 0x744a, 0x744c, 0x745e],
-  # Navi32
+  # Navi31 (RDNA3) - Radeon RX 7900 series, Pro W7800, Pro V710
+  "gfx1100": [0x7448, 0x7449, 0x744a, 0x744c, 0x745e, 0x7460, 0x7461],
+  # Navi32 (RDNA3) - Radeon RX 7800/7700 series, Pro W7700
   "gfx1101": [0x7470, 0x747e],
-  # Navi33
-  "gfx1102": [0x7480, 0x7483, 0x7489, 0x7499],
+  # Navi33 (RDNA3) - Radeon RX 7600 series, Pro W7500/W7400, Steam Machine
+  "gfx1102": [0x7480, 0x7481, 0x7483, 0x7489, 0x7499],
+
+  # Navi44 (RDNA4) - Radeon RX 9060, 9060 XT
+  "gfx1200": [0x7590],
+  # Navi48 (RDNA4) - Radeon RX 9070, 9070 XT, 9070 GRE, Radeon AI PRO R9700
+  "gfx1201": [0x7550, 0x7551],
 }
 
 def staticVars(**kwargs):


### PR DESCRIPTION
## Summary
- Add missing RDNA3 (gfx11xx) and RDNA4 (gfx12xx) device IDs from upstream Mesa/DRM amdgpu.ids
- gfx1100: Add 0x7460 (Pro V710), 0x7461 (Pro V710 MxGPU)
- gfx1102: Add 0x7481 (Steam Machine)
- gfx1200: Add 0x7590 (RX 9060 series)
- gfx1201: Add 0x7550, 0x7551 (RX 9070 series, AI PRO R9700)

## Test plan
- [x] Verified `python3 rocm_agent_enumerator` runs without errors
- [x] Verified Python syntax with `py_compile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)